### PR TITLE
fix compile errors

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1507,7 +1507,7 @@
 	if(!UWC) return
 	var/datum/category_item/underwear/UWI = all_underwear[UWC.name]
 	if(!UWI || UWI.name == "None")
-		to_chat(src, "<span class='notice'>You do not have [UWC.gender==PLURAL ? "[UWC.display_name]" : "\a [UWC.display_name]"].</span>")
+		to_chat(src, "<span class='notice'>You do not have [UWC.gender==PLURAL ? "[UWC.display_name]" : "a [UWC.display_name]"].</span>")
 		return
 	hide_underwear[UWC.name] = !hide_underwear[UWC.name]
 	update_underwear(1)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1528,22 +1528,22 @@
 		stuttering = max(stuttering, 5)
 
 	if(shock_stage == 40)
-		to_chat(src, "<span class='danger'>[pick(\"The pain is excruciating\", \"Please, just end the pain\", \"Your whole body is going numb\")]!</span>")
+		to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please\, just end the pain", "Your whole body is going numb")]!</span>")
 
 	if (shock_stage >= 60)
 		if(shock_stage == 60) emote("me",1,"'s body becomes limp.")
 		if (prob(2))
-			to_chat(src, "<span class='danger'>[pick(\"The pain is excruciating\", \"Please, just end the pain\", \"Your whole body is going numb\")]!</span>")
+			to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please\, just end the pain", "Your whole body is going numb")]!</span>")
 			Weaken(20)
 
 	if(shock_stage >= 80)
 		if (prob(5))
-			to_chat(src, "<span class='danger'>[pick(\"The pain is excruciating\", \"Please, just end the pain\", \"Your whole body is going numb\")]!</span>")
+			to_chat(src, "<span class='danger'>[pick("The pain is excruciating", "Please\, just end the pain", "Your whole body is going numb")]!</span>")
 			Weaken(20)
 
 	if(shock_stage >= 120)
 		if (prob(2))
-			to_chat(src, "<span class='danger'>[pick(\"You black out\", \"You feel like you could die any moment now\", \"You're about to lose consciousness\")]!</span>")
+			to_chat(src, "<span class='danger'>[pick("You black out", "You feel like you could die any moment now", "You\'re about to lose consciousness")]!</span>")
 			Paralyse(5)
 
 	if(shock_stage == 150)


### PR DESCRIPTION
Looks like it wasn't the double quotes that needed escaping, it was some commas and apostrophes